### PR TITLE
Add support for https urls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ lazy val root =
       ),
       publishArtifact := true,
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-      scalaVersion := "2.13.3",
-      crossScalaVersions := Seq("2.12.12", "2.13.3")
+      scalaVersion := "2.13.7",
+      crossScalaVersions := Seq("2.12.15", "2.13.7")
     )
 
 // *****************************************************************************
@@ -37,11 +37,11 @@ lazy val library =
   new {
 
     object Version {
-      val zio                 = "1.0.3"
-      val sttp                = "2.2.8"
-      val circe               = "0.13.0"
-      val scalaLogging        = "3.9.2"
-      val typesafeConfig      = "1.4.0"
+      val zio                 = "1.0.12"
+      val sttp                = "2.2.10"
+      val circe               = "0.14.1"
+      val scalaLogging        = "3.9.4"
+      val typesafeConfig      = "1.4.1"
       val testContainersScala = "0.38.9"
 
     }

--- a/src/main/scala/io/sqooba/oss/promql/PrometheusClient.scala
+++ b/src/main/scala/io/sqooba/oss/promql/PrometheusClient.scala
@@ -34,7 +34,9 @@ class PrometheusClient(
 ) extends PrometheusService.Service
     with LazyLogging {
 
-  private val endpoint = uri"http://${config.host}:${config.port}"
+  private val scheme = if (config.ssl) "https" else "http"
+
+  private[promql] val endpoint = uri"${scheme}://${config.host}:${config.port}"
   logger.info(s"Sending to endpoint $endpoint")
   private val importEndpoint = endpoint.path("/api/v1/import")
   logger.info(s"Import endpoint is $importEndpoint")

--- a/src/main/scala/io/sqooba/oss/promql/PrometheusClientConfig.scala
+++ b/src/main/scala/io/sqooba/oss/promql/PrometheusClientConfig.scala
@@ -13,6 +13,7 @@ import zio.{ Has, RLayer, Task, ZLayer }
 case class PrometheusClientConfig(
   host: String,
   port: Int,
+  ssl: Boolean,
   maxPointsPerTimeseries: Int,
   retryNumber: Int,
   parallelRequests: Int
@@ -20,11 +21,28 @@ case class PrometheusClientConfig(
 
 object PrometheusClientConfig {
 
+  /**
+   * Shameful late addition of the SSL support: there might be a more elegant way of
+   * supporting default options, but for now we'll stick with this.
+   *
+   * We can consider defaulting to true at some point, though the most likely worst case is that
+   * clients connect to an https endpoint using http, which will fail.
+   *
+   * @return true if the config contains `ssl = true`, false otherwise.
+   */
+  private def readSslFlag(config: Config): Boolean =
+    if (config.hasPath("ssl")) {
+      config.getBoolean("ssl")
+    } else {
+      false
+    }
+
   def from(config: Config): Task[PrometheusClientConfig] =
     Task {
       PrometheusClientConfig(
         config.getString("host"),
         config.getInt("port"),
+        readSslFlag(config),
         config.getInt("maxPointsPerTimeseries"),
         config.getInt("retryNumber"),
         config.getInt("parallelRequests")
@@ -36,6 +54,7 @@ object PrometheusClientConfig {
       PrometheusClientConfig(
         config.getString("host"),
         config.getInt("port"),
+        readSslFlag(config),
         config.getInt("max-points-per-timeseries"),
         config.getInt("retry-number"),
         config.getInt("parallel-requests")

--- a/src/test/scala/io/sqooba/oss/utils/PromClientRunnable.scala
+++ b/src/test/scala/io/sqooba/oss/utils/PromClientRunnable.scala
@@ -36,6 +36,7 @@ abstract class PromClientRunnable extends RunnableSpec[PromClientEnv, Any] {
     PrometheusClientConfig(
       container.container.getContainerIpAddress(),
       container.container.getFirstMappedPort(),
+      ssl = false,
       maxPointsPerTimeseries = 30000,
       retryNumber = 3,
       parallelRequests = 3


### PR DESCRIPTION
First draft for SSL support, better late than never.

Includes an update of the dependencies.

(Will get the commit through via the internal repo once we are happy with it)

Unrelated: a test fails with what looks like an interval boundary inclusion or exclusion bug:

```
 - VictoriaMetricsApp
[info]   - put
[info]     - Should retrieve the inserted points
[info]       `{
[info]   val relevantMetrics = result.asInstanceOf[MatrixResponseData].result.filter(((p: io.sqooba.oss.promql.metrics.MatrixMetric) => p.metric.equals(cpuMetric)));
[info]   val compatibleSerie = relevantMetrics.head.values.map[(java.time.Instant, Double), List[(java.time.Instant, Double)]](((i: (java.time.Instant, String)) => scala.Tuple2.apply[java.time.Instant, Double](i._1, scala.Predef.augmentString(i._2).toDouble)))(scala.collection.immutable.List.canBuildFrom[(java.time.Instant, Double)]);
[info]   val exclusiveEnd = compatibleSerie.slice(0, compatibleSerie.size.-(1));
[info]   exclusiveEnd
[info] }` = List((2020-12-12T00:00:00Z,28.0), (2020-12-12T00:00:10Z,96.0), (2020-12-12T00:00:20Z,73.0), (2020-12-12T00:00:30Z,38.0), (2020-12-12T00:00:40Z,8.0), (2020-12-12T00:00:50Z,19.0), (2020-12-12T00:01:00Z,94.0), (2020-12-12T00:01:10Z,96.0), (2020-12-12T00:01:20Z,87.0), (2020-12-12T00:01:30Z,56.0), (2020-12-12T00:01:40Z,37.0), (2020-12-12T00:01:50Z,94.0), (2020-12-12T00:02:00Z,24.0), (2020-12-12T00:02:10Z,25.0), (2020-12-12T00:02:20Z,24.0), (2020-12-12T00:02:30Z,26.0), (2020-12-12T00:02:40Z,0.0), (2020-12-12T00:02:50Z,97.0), (2020-12-12T00:03:00Z,47.0), (2020-12-12T00:03:10Z,62.0), (2020-12-12T00:03:20Z,9.0), (2020-12-12T00:03:30Z,54.0), (2020-12-12T00:03:40Z,34.0)) did not satisfy equalTo(List((2020-12-12T00:00:00Z,28.0), (2020-12-12T00:00:10Z,96.0), (2020-12-12T00:00:20Z,73.0), (2020-12-12T00:00:30Z,38.0), (2020-12-12T00:00:40Z,8.0), (2020-12-12T00:00:50Z,19.0), (2020-12-12T00:01:00Z,94.0), (2020-12-12T00:01:10Z,96.0), (2020-12-12T00:01:20Z,87.0), (2020-12-12T00:01:30Z,56.0), (2020-12-12T00:01:40Z,37.0), (2020-12-12T00:01:50Z,94.0), (2020-12-12T00:02:00Z,24.0), (2020-12-12T00:02:10Z,25.0), (2020-12-12T00:02:20Z,24.0), (2020-12-12T00:02:30Z,26.0), (2020-12-12T00:02:40Z,0.0), (2020-12-12T00:02:50Z,97.0), (2020-12-12T00:03:00Z,47.0), (2020-12-12T00:03:10Z,62.0), (2020-12-12T00:03:20Z,9.0), (2020-12-12T00:03:30Z,54.0), (2020-12-12T00:03:40Z,34.0), (2020-12-12T00:03:50Z,20.0)))
[info]       at /Users/julien/git/scala-promql-client/src/test/scala/io/sqooba/oss/promql/PrometheusAppSpec.scala:53
```